### PR TITLE
Add deactivation button

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
             echo "Virtualenv active: .venv"
             echo "Installing environment packages (numpy, otter-grader, datascience)"
             pip install --upgrade pip
+            pip install build twine hatchling hatch-jupyter-builder
             pip install numpy otter-grader datascience
             echo "Installing JupyterLab + kernel in venv"
             pip install jupyterlab ipykernel
@@ -54,6 +55,8 @@
             jupyter labextension develop . --overwrite
             echo "jupytutor dev shell ready"
             echo "Run JupyterLab: jupyter lab"
+            echo "Or, to build prod release: jlpm install; jlpm build:prod; python -m build"
+            echo "(to clean first: jlpm clean:all && rm -rf dist build *.egg-info jupytutor/labextension)"
           '';
         };
       });

--- a/package.json
+++ b/package.json
@@ -61,14 +61,17 @@
         "@jupyterlab/cells": "^4.4.4",
         "@jupyterlab/notebook": "^4.4.4",
         "@lumino/widgets": "^2.7.1",
+        "@szhsin/react-menu": "^4.5.1",
         "browser": "^0.2.6",
         "html-to-text": "^9.0.5",
+        "immer": "^11.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
-        "zod": "^4.3.5"
+        "zod": "^4.3.5",
+        "zustand": "^5.0.10"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import { ConfigSchema } from './schemas/config';
  *
  * Structure ~/.config/jupytutor/config.json the same as the exported config object.
  */
-export const defaultConfig: z.output<typeof ConfigSchema> = {
+export const defaultConfig: z.input<typeof ConfigSchema> = {
   pluginEnabled: true,
   api: {
     baseURL: 'http://localhost:3000/'
@@ -31,6 +31,7 @@ export const defaultConfig: z.output<typeof ConfigSchema> = {
 
   rules: [
     {
+      _comment: 'Default rule: disable chat in all cells',
       config: {
         chatEnabled: false
       }
@@ -73,9 +74,18 @@ export const defaultConfig: z.output<typeof ConfigSchema> = {
                 }
               },
               {
-                tags: {
-                  any: 'jupytutor_grader_cell'
-                }
+                OR: [
+                  {
+                    tags: {
+                      any: 'jupytutor:grader_cell'
+                    }
+                  },
+                  {
+                    tags: {
+                      any: 'jupytutor_grader_cell'
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -120,9 +130,18 @@ export const defaultConfig: z.output<typeof ConfigSchema> = {
                 }
               },
               {
-                tags: {
-                  any: 'jupytutor_grader_cell'
-                }
+                OR: [
+                  {
+                    tags: {
+                      any: 'jupytutor:grader_cell'
+                    }
+                  },
+                  {
+                    tags: {
+                      any: 'jupytutor_grader_cell'
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -164,6 +183,30 @@ export const defaultConfig: z.output<typeof ConfigSchema> = {
         chatEnabled: true,
         chatProactive: true,
         quickResponses: ['Evaluate my answer.']
+      }
+    },
+    {
+      _comment:
+        "Disable proactive mode when there's an explicit disable tag (best to keep this rule toward the end)",
+      when: {
+        tags: {
+          any: 'jupytutor:disable_proactive'
+        }
+      },
+      config: {
+        chatEnabled: false
+      }
+    },
+    {
+      _comment:
+        "Disable when there's an explicit disable tag (best to keep this rule at the end)",
+      when: {
+        tags: {
+          any: 'jupytutor:disable'
+        }
+      },
+      config: {
+        chatEnabled: false
       }
     }
   ]

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -50,28 +50,54 @@ export const ConfigSchema = z.object({
     )
     .default([
       {
+        _comment: 'Jupytutor always available, but only when manually invoked',
         config: {
           chatEnabled: true,
           chatProactive: false
         }
       },
       {
-        "when": {
-          "AND": [
+        _comment: "Display proactively when there's an error in a code cell",
+        when: {
+          AND: [
             {
-              "cellType": "code"
+              cellType: 'code'
             },
             {
-              "hasError": true
+              hasError: true
             }
           ]
         },
-        "config": {
-          "chatEnabled": true,
-          "chatProactive": true,
-          "quickResponses": ["Explain this error."]
+        config: {
+          chatEnabled: true,
+          chatProactive: true,
+          quickResponses: ['Explain this error.']
         }
       },
+      {
+        _comment:
+          "Disable proactive mode when there's an explicit disable tag (best to keep this rule toward the end)",
+        when: {
+          tags: {
+            any: 'jupytutor:disable_proactive'
+          }
+        },
+        config: {
+          chatEnabled: false
+        }
+      },
+      {
+        _comment:
+          "Disable when there's an explicit disable tag (best to keep this rule at the end)",
+        when: {
+          tags: {
+            any: 'jupytutor:disable'
+          }
+        },
+        config: {
+          chatEnabled: false
+        }
+      }
     ])
     .describe(
       'List of rules with conditions (deciding whether the rule should apply to a particular cell) and configurations. Rules are applied in order, with later rules overriding earlier ones (if they apply to a particular cell).'
@@ -109,6 +135,20 @@ export const ConfigSchema = z.object({
         })
         .prefault({})
     })
+    .prefault({}),
+
+  preferences: z
+    .object({
+      proactiveEnabled: z
+        .boolean()
+        .default(true)
+        .describe(
+          'Global setting to enable or disable proactive chat behavior. Overrides notebook rule configuration.'
+        )
+    })
+    .describe(
+      "User preferences set for the plugin; generally shouldn't be included as part of an assignment, but rather set after the notebook has been started by the student."
+    )
     .prefault({})
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+import { PluginConfig } from './schemas/config';
+
+export const useJupytutorReactState = create(() => ({
+  notebookConfig: null! as PluginConfig // shh
+}));
+
+export const useNotebookPreferences = () => {
+  return useJupytutorReactState(state => state.notebookConfig.preferences);
+}

--- a/style/Jupytutor.css
+++ b/style/Jupytutor.css
@@ -44,6 +44,18 @@
   background-color: var(--jp-brand-color0);
 }
 
+.jupytutor .menu-btn {
+  background-color: transparent;
+  color: var(--jp-content-font-color2);
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.jupytutor .menu-btn:hover {
+  background-color: rgba(128, 128, 128, 0.3);
+}
+
 .jupytutor p {
   margin-top: 10px;
   font-style: italic;
@@ -612,6 +624,7 @@
 .chat-input-container.loading {
   animation: containerPulse 2s ease-in-out infinite;
   position: relative;
+  overflow-x: hidden;
 }
 
 .chat-input-container.loading::before {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3285,6 +3285,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@szhsin/react-menu@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "@szhsin/react-menu@npm:4.5.1"
+  dependencies:
+    react-transition-state: ^2.3.1
+  peerDependencies:
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
+  checksum: 973a470da4811fd8512b7237889f211836801bc7c926a2676763b3c48aefc33eaff74006675c98f31b063299c7509317b8b80f41200e4a337dc0e81f852a0f80
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:2":
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
@@ -7144,6 +7156,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^11.1.3":
+  version: 11.1.3
+  resolution: "immer@npm:11.1.3"
+  checksum: c2656e0d8603055df270cc1cf688fba8ae6c13be207a9182dd8a250188cbcba2f8d7bea9629419220a71464a3c061aaa31d2226b6ef9311d355fc14c423bba82
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -8119,6 +8138,7 @@ __metadata:
     "@jupyterlab/notebook": ^4.4.4
     "@jupyterlab/testutils": ^4.0.0
     "@lumino/widgets": ^2.7.1
+    "@szhsin/react-menu": ^4.5.1
     "@types/html-to-text": ^9.0.4
     "@types/jest": ^29.2.0
     "@types/json-schema": ^7.0.11
@@ -8134,6 +8154,7 @@ __metadata:
     eslint-plugin-prettier: ^5.0.0
     html-loader: ^5.1.0
     html-to-text: ^9.0.5
+    immer: ^11.1.3
     jest: ^29.2.0
     npm-run-all2: ^7.0.1
     prettier: ^3.0.0
@@ -8156,6 +8177,7 @@ __metadata:
     webpack-cli: ^6.0.1
     yjs: ^13.5.0
     zod: ^4.3.5
+    zustand: ^5.0.10
   languageName: unknown
   linkType: soft
 
@@ -9866,6 +9888,16 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
+  languageName: node
+  linkType: hard
+
+"react-transition-state@npm:^2.3.1":
+  version: 2.3.2
+  resolution: "react-transition-state@npm:2.3.2"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 2b2ec25a51791a2361b41a3a7992988ba21b0f384d1dd81f5c3adf2b7b8350385bd2f2a77fb907ee96d35727f8b13c2a27612210d61dca5f3a62d88ae190f44e
   languageName: node
   linkType: hard
 
@@ -12001,5 +12033,26 @@ __metadata:
   version: 4.3.5
   resolution: "zod@npm:4.3.5"
   checksum: 68691183a91c67c4102db20139f3b5af288c59b4b11eb2239d712aae99dc6c1cecaeebcb0c012b44489771be05fecba21e79f65af4b3163b220239ef0af3ec49
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^5.0.10":
+  version: 5.0.10
+  resolution: "zustand@npm:5.0.10"
+  peerDependencies:
+    "@types/react": ">=18.0.0"
+    immer: ">=9.0.6"
+    react: ">=18.0.0"
+    use-sync-external-store: ">=1.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+    use-sync-external-store:
+      optional: true
+  checksum: 52d39ad5a0a496a443ced50e773a47df4bda4f718c96e45a08c92675e45d7ac77ce75903b8e3754f17a2e99c71f5864ae8c2b2477aeb4c6f5c2a19e3e64e57ba
   languageName: node
   linkType: hard


### PR DESCRIPTION
<img width="825" height="321" alt="image" src="https://github.com/user-attachments/assets/bdd85e77-a4b3-4a55-a0cf-56205a6eb2fb" />

<img width="446" height="225" alt="image" src="https://github.com/user-attachments/assets/38114f5a-bf08-4d5b-b3b1-444a77f910ce" />

This writes into the `preferences` section of the config in the notebook metadata (which I'm thinking will be where we can stash things that don't come from the notebook author).

We'll want to revisit this design (I'll make a task in the tracker, once I've set up the tracker); for now, this is just a best-effort way to get something in front of students. Some thoughts on this design:

- There's no convenient way to reactivate, unless you haven't yet dismissed existing chats
  - I think this is fine, because what I want to do in the future is add a 'manual invocation' button, or similar, probably in cell toolbars, so that students can choose to pop up Jupytutor even when it didn't pop up automatically; the idea here is that disabling Jupytutor will really amount to disabling the clippy-style initiative-taking, but students can still manually invoke if they want. Then, we just change this menu item so that instead of disabling completely, it disables just the proactive pop-ups, and students can turn this behavior back on by coming back to this menu.
- Maybe a different button, or it goes somewhere else -- I prefer it on the left, I think, but this overlaps awkwardly with the output-area-enter button for now.
- This depends on the notebook being saved, to save the setting.