### PR TITLE
Patch 'o' key command issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,12 +46,14 @@
             pip install build twine hatchling hatch-jupyter-builder
             pip install numpy otter-grader datascience
             echo "Installing JupyterLab + kernel in venv"
-            pip install jupyterlab ipykernel
+            pip install jupyterlab ipykernel notebook==7.5.0
+            echo "Installing classic Notebook + enabling server extension"
             python -m ipykernel install --user --name jupytutor-venv --display-name "Jupytutor (venv)"
             # echo "Next: jlpm install"
             jlpm install
             # echo "Then: pip install -e ."
             pip install -e .
+            jupyter server extension enable notebook
             jupyter labextension develop . --overwrite
             echo "jupytutor dev shell ready"
             echo "Run JupyterLab: jupyter lab"

--- a/src/Jupytutor.tsx
+++ b/src/Jupytutor.tsx
@@ -14,7 +14,11 @@ import NotebookContextRetrieval, {
 import { makeAPIRequest } from './helpers/makeAPIRequest';
 import { formatMessage } from './helpers/messageFormatting';
 import { PluginConfig } from './schemas/config';
-import { useJupytutorReactState, useNotebookPreferences } from './store';
+import {
+  useJupytutorReactState,
+  useNotebookPreferences,
+  usePatchKeyCommand750
+} from './store';
 
 export interface JupytutorProps {
   autograderResponse: string | undefined;
@@ -282,6 +286,11 @@ export const Jupytutor = (props: JupytutorProps): JSX.Element => {
         //, chatHistory
       );
   }, [chatHistory]);
+
+  const patchKeyCommand750 = usePatchKeyCommand750();
+  const dataProps = patchKeyCommand750
+    ? { 'data-lm-suppress-shortcuts': true }
+    : {};
 
   /**
    * Converts a base64 data URL to a File object
@@ -662,7 +671,7 @@ export const Jupytutor = (props: JupytutorProps): JSX.Element => {
 
   return (
     // Note we can use the same CSS classes from Method 1
-    <div className={`jupytutor ${isLoading ? 'loading' : ''}`}>
+    <div className={`jupytutor ${isLoading ? 'loading' : ''}`} {...dataProps}>
       <div className="chat-container" ref={chatContainerRef}>
         {chatHistory
           .filter(item => !item.noShow)

--- a/src/helpers/patch-keycommand-7.5.0.ts
+++ b/src/helpers/patch-keycommand-7.5.0.ts
@@ -1,0 +1,18 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { devLog } from './dev';
+import { useJupytutorReactState } from '../store';
+
+// https://github.com/team-jupytutor/jupytutor/issues/25#issue-3841086723
+// issue introduced in Jupyter Notebook v7.5.0, patched in v7.5.1
+export const patchKeyCommand750 = (app: JupyterFrontEnd) => {
+  if (app.version === '7.5.0') {
+    // from commands/src/index.ts:
+    //  When the keydown event is processed, if the event target or any of its
+    //  ancestor nodes has a `data-lm-suppress-shortcuts` attribute, its keydown
+    //  events will not invoke commands.
+
+    devLog(() => "Patching key 'o' command for Jupyter Notebook v7.5.0");
+
+    useJupytutorReactState.setState({ patchKeyCommand750: true });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import NotebookContextRetrieval, {
 import parseNB from './helpers/parseNB';
 import { ConfigSchema, PluginConfig } from './schemas/config';
 import { useJupytutorReactState } from './store';
+import { patchKeyCommand750 } from './helpers/patch-keycommand-7.5.0';
 
 export const DEMO_PRINTS = true;
 
@@ -46,6 +47,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
   autoStart: true,
   requires: [INotebookTracker],
   activate: async (app: JupyterFrontEnd, notebookTracker: INotebookTracker) => {
+    patchKeyCommand750(app);
+
     // Get the DataHub user identifier
     const userId = getUserIdentifier();
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,9 +2,14 @@ import { create } from 'zustand';
 import { PluginConfig } from './schemas/config';
 
 export const useJupytutorReactState = create(() => ({
-  notebookConfig: null! as PluginConfig // shh
+  notebookConfig: null! as PluginConfig, // shh
+  patchKeyCommand750: false
 }));
 
 export const useNotebookPreferences = () => {
   return useJupytutorReactState(state => state.notebookConfig.preferences);
-}
+};
+
+export const usePatchKeyCommand750 = () => {
+  return useJupytutorReactState(state => state.patchKeyCommand750);
+};


### PR DESCRIPTION
## What does this PR do?

See #25. Jupyter 7.5.0 has an issue that swallows 'o' events even from within a text field.

There's a way to pre-empt key event handling entirely for a particular DOM tree, which I think is fine to do while we're in the Jupytutor element -- in fact, I think the notebook (not lab) view that has this issue only has this one keyboard shortcut set up anyway.

---

## How should this be manually tested?

- test that we can type 'o' in an environment (`jupyter notebook`, v7.5.0) where it didn't work before
- test that other obvious key events (enter) still work
- looks like this also prevents shift+enter from working to rerun the cell, which is fine by me -- that would lose the jupytutor context currently, anyway.

---

## Tests

- [ ] I've included tests with this PR
- [ ] I'll include tests with another PR (link to GH issue for these tests)
- [X] Tests aren't needed for this change (explain why)
  - ehh, it would be good to test this (especially with the imminent React and React state refactors which might break this), but frontend tests aren't a priority rn

---

## Related PRs

log call is broken until we merge #20. this might cause merge conflicts with #31 

## Checklist

- [ ] I've resolved all linter violations (except when I have a question about a specific rule)
- [x] I've validated any UI changes in dark and light mode
- [x] I've validated any UI changes in the Jupyter Lab and single-column notebook views
- [ ] I've reviewed the entire diff for the PR for dead code, typos, overly complicated code, etc.
- [ ] I've added GitHub comments on code for which I want specific feedback or which warrant extra explanation
- [ ] I've requested a review if ready, or if changes have been made in response to a review

