### PR TITLE
Fix ChatMenu styling

### DIFF
--- a/src/Components/ChatMenu.tsx
+++ b/src/Components/ChatMenu.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuButton, MenuItem } from '@szhsin/react-menu';
 import { useNotebookPreferences } from '../store';
-import '../../style/index.css';
+import '@szhsin/react-menu/dist/index.css';
 
 interface ChatMenuProps {
   setProactiveEnabled: (enabled: boolean) => void;


### PR DESCRIPTION
## What does this PR do?

We lost this style import in #31

---

## Screenshots

before:
<img width="480" height="223" alt="image" src="https://github.com/user-attachments/assets/35bcd9b9-5023-47f4-b8c3-02d09fd062c7" />


after:
<img width="480" height="223" alt="image" src="https://github.com/user-attachments/assets/f6f017ee-a245-48a0-9ce1-287b03802844" />



---

## How should this be manually tested?

see above

---

## Tests

- [ ] I've included tests with this PR
- [ ] I'll include tests with another PR (link to GH issue for these tests)
- [X] Tests aren't needed for this change (explain why)
  - this would be a good candidate for frontend screenshot tests (but still need to get there!)

---

## Related PRs

introduced in #31

---

## Checklist

- [x] I've resolved all linter violations (except when I have a question about a specific rule)
- [X] I've validated any UI changes in dark and light mode
  - should probably be dark, but punt on this
- [ ] I've validated any UI changes in the Jupyter Lab and single-column notebook views
- [x] I've reviewed the entire diff for the PR for dead code, typos, overly complicated code, etc.
- [x] I've added GitHub comments on code for which I want specific feedback or which warrant extra explanation
- [ ] I've requested a review if ready, or if changes have been made in response to a review

