### PR TITLE
Bail early in JS activation if not on d8/d140 hub (or localhost)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,19 @@ const plugin: JupyterFrontEndPlugin<void> = {
   autoStart: true,
   requires: [INotebookTracker],
   activate: async (app: JupyterFrontEnd, notebookTracker: INotebookTracker) => {
+    if (
+      !(
+        window.location.host === 'data8.datahub.berkeley.edu' ||
+        window.location.host === 'prob140.datahub.berkeley.edu' ||
+        window.location.hostname === 'localhost'
+      )
+    ) {
+      // bail early while we work on early versions of the plugin --
+      //   don't want to have negative impact on `datahub.berkeley.edu`,
+      //   including possibly leaking notebook watchers / json metadata parsers
+      return;
+    }
+
     patchKeyCommand750(app);
 
     // Get the DataHub user identifier


### PR DESCRIPTION
## What does this PR do?

closes #37.

This is a silly quick solution -- we want to make sure that deploying on the `datahub.` image is unlikely to have negative impacts, and this means avoiding potential performance issues (which have occurred in the past). Once we've improved our CI/CD (#13) to better flag robustness issues, this should become unnecessary.

I looked into whether we can do this in the Python code, avoiding loading the JS bundle at all, but it gets tricky. Not sure which steps happen in the initial install, vs which happen in the deployment to a new server. This patch should still avoid issues if we accidentally introduce perf issues or bugs in the notebook parsing code, the tracker watching code, etc.

---

## How should this be manually tested?

Jupytutor loads (console log + widget appears) on localhost, but not on 127.0.0.1

---

## Risks

Are there any concerns about deploying this PR?

- We may forget about this! Created tracking issue #41
- Haven't tested _exactly_ on the prod hubs, but should be fine -- I copied the host value from console on prod

---

## Checklist

- [ ] I've resolved all linter violations (except when I have a question about a specific rule)
- [ ] I've validated any UI changes in dark and light mode
- [ ] I've validated any UI changes in the Jupyter Lab and single-column notebook views
- [ ] I've reviewed the entire diff for the PR for dead code, typos, overly complicated code, etc.
- [ ] I've added GitHub comments on code for which I want specific feedback or which warrant extra explanation
- [ ] I've requested a review if ready, or if changes have been made in response to a review

