### PR TITLE
Fix cell index off-by-one

### DIFF
--- a/src/Jupytutor.tsx
+++ b/src/Jupytutor.tsx
@@ -14,21 +14,18 @@ import { useCellConfig, usePatchKeyCommand750, useWidgetState } from './store';
 export interface JupytutorProps {
   cellId: string;
   notebookPath: string;
-  activeIndex: number;
 }
 
 export const Jupytutor = (props: JupytutorProps): JSX.Element => {
   const widgetState = useWidgetState();
   const quickResponses = useCellConfig()?.quickResponses ?? [];
 
-  const { activeIndex } = props;
-
   const patchKeyCommand750 = usePatchKeyCommand750();
   const dataProps = patchKeyCommand750
     ? { 'data-lm-suppress-shortcuts': true }
     : {};
 
-  const queryAPI = useQueryAPIFunction(activeIndex);
+  const queryAPI = useQueryAPIFunction();
 
   const callSuggestion = async (suggestion: string) => {
     if (widgetState.isLoading) return;
@@ -70,8 +67,7 @@ class JupytutorWidget extends ReactWidget {
   constructor(
     props: JupytutorProps = {
       cellId: '',
-      notebookPath: '',
-      activeIndex: -1
+      notebookPath: ''
     }
   ) {
     super();

--- a/src/helpers/parseNB.ts
+++ b/src/helpers/parseNB.ts
@@ -9,6 +9,7 @@ import { extractLinksAndImages } from './markdown/extract-links-images';
 export type ParsedCellType = 'code' | 'markdown' | 'unknown';
 
 export interface ParsedCell {
+  id: string;
   type: ParsedCellType | null;
   text: string;
   editable: boolean;
@@ -24,7 +25,7 @@ export interface ParsedCell {
  * @param cell the Jupyter Cell in question
  * @param success whether or not the cell ran successfully without error
  *
- * @returns allCells, activeIndex, allowed
+ * @returns allCells
  */
 const parseNB = (notebook: Notebook): ParsedCell[] => {
   const cells = notebook.model?.cells ?? [];
@@ -77,6 +78,7 @@ function parseCellModel(cell: ICellModel): ParsedCell {
   }
 
   return {
+    id: cell.id,
     type,
     text,
     editable: cell.getMetadata('editable') ?? true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,8 +320,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
           const jupytutor = new JupytutorWidget({
             cellId: cell.model.id,
             notebookPath,
-            // TODO: rejig 'active cell' logic
-            activeIndex: notebook.activeCellIndex
           });
 
           // Check if there's already a JupyTutor widget in this cell and remove it


### PR DESCRIPTION
## What does this PR do?

I removed the 'active index correction' in an earlier refactor, but it did reintroduce the bug that some requests (on code cells, in particular) will include context from one cell too far in the notebook.

This PR moves away from using the 'active index' of the notebook, which is based on user interaction in the Jupyter interface, and towards anchoring based on what cell the actual widget is rendering on. We also abandon cell _index_ as something to pass around in most cases, instead using cell _ID_ and working backwards to find the index when necessary. This is slightly less efficient than keeping the redundant information around, but it's still generally better practice to avoid storing information which might get out of sync; we can memoize the index-finding code down the road if it proves to be a bottleneck.

---

## How should this be manually tested?

I added the devLog call to `chat-api.ts` for `HEAD^` to verify that n+1 cells were being sent with the old code. Then I checked again with the current tip of this PR branch and saw that that's no longer the case.

closes #45 